### PR TITLE
Add continuous integration jobs

### DIFF
--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -14,11 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+      run:
+        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+        && cd ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
-      run: ${{inputs.jlm-root-dir}}/configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+      run: ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -14,17 +14,15 @@ runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run: |
-        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
-        cd ${{inputs.jlm-root-dir}}
+      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
-      run: ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+      run: ${{inputs.jlm-root-dir}}/configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"
-      run: make -j `nproc` -O all
+      run: make -C ${{inputs.jlm-root-dir}} -j `nproc` -O all
       shell: bash
 
     - name: "Add executables to PATH"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -15,13 +15,13 @@ runs:
   steps:
     - name: "Clone jlm"
       run:
-        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}} \
-        && cd ${{inputs.jlm-root-dir}} \
-        && pwd
+        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
-      run: ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+      run:
+        cd ${{inputs.jlm-root-dir}} \
+        && ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -2,10 +2,6 @@ name: "Build jlm"
 description: "Configures and builds jlm along with the necessary dependencies."
 
 inputs:
-  jlm-root-dir:
-    description: "Set jlm root directory"
-    required: true
-
   cxx:
     description: "Set C++ compiler."
     required: true
@@ -14,19 +10,21 @@ runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+      run: git clone https://github.com/phate/jlm.git /tmp/jlm
       shell: bash
 
     - name: "Configure jlm"
       run: |
-        cd ${{inputs.jlm-root-dir}} && \
-        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+        cwd=$(pwd) && \
+        cd /tmp/jlm && \
+        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}} && \
+        cd ${cwd}
       shell: bash
 
     - name: "Compile jlm"
-      run: make -C ${{inputs.jlm-root-dir}} -j `nproc` -O all
+      run: make -C /tmp/jlm -j `nproc` -O all
       shell: bash
 
     - name: "Add executables to PATH"
-      run: echo '${{inputs.jlm-root-dir}}/build' >> $GITHUB_PATH
+      run: echo '/tmp/jlm/build' >> $GITHUB_PATH
       shell: bash

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -20,8 +20,8 @@ runs:
 
     - name: "Configure jlm"
       run:
-        cd ${{inputs.jlm-root-dir}} \
-        && ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+        cd ${{inputs.jlm-root-dir}} && \
+        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -1,0 +1,32 @@
+name: "Build jlm"
+description: "Configures and builds jlm along with the necessary dependencies."
+
+inputs:
+  jlm-root-dir:
+    description: "Set jlm root directory"
+    required: true
+
+  cxx:
+    description: "Set C++ compiler."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Clone jlm"
+      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+      shell: bash
+
+    - name: "Configure jlm"
+      run: |
+        cd ${{inputs.jlm-root-dir}}
+        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+      shell: bash
+
+    - name: "Compile jlm"
+      run: make -j `nproc` -O all
+      shell: bash
+
+    - name: "Add executables to PATH"
+      run: echo '${{inputs.jlm-root-dir}}/build' >> $GITHUB_PATH
+      shell: bash

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -15,8 +15,9 @@ runs:
   steps:
     - name: "Clone jlm"
       run:
-        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
-        && cd ${{inputs.jlm-root-dir}}
+        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}} \
+        && cd ${{inputs.jlm-root-dir}} \
+        && pwd
       shell: bash
 
     - name: "Configure jlm"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -14,13 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+      run: |
+        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+        cd ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
-      run: |
-        cd ${{inputs.jlm-root-dir}}
-        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+      run: ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -14,12 +14,11 @@ runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run:
-        git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
+      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
-      run:
+      run: |
         cd ${{inputs.jlm-root-dir}} && \
         ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -4,7 +4,8 @@ description: "Configures and builds jlm along with the necessary dependencies."
 inputs:
   cxx:
     description: "Set C++ compiler for compiling jlm."
-    required: true
+    default: "clang++"
+    required: false
 
   jlm-root-dir:
     description: "The directory used for cloning jlm into."

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -3,26 +3,31 @@ description: "Configures and builds jlm along with the necessary dependencies."
 
 inputs:
   cxx:
-    description: "Set C++ compiler."
+    description: "Set C++ compiler for compiling jlm."
     required: true
+
+  jlm-root-dir:
+    description: "The directory used for cloning jlm into."
+    default: "/tmp/jlm"
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: "Clone jlm"
-      run: git clone https://github.com/phate/jlm.git /tmp/jlm
+      run: git clone https://github.com/phate/jlm.git ${{inputs.jlm-root-dir}}
       shell: bash
 
     - name: "Configure jlm"
       run: |
-        cd /tmp/jlm && \
+        cd ${{inputs.jlm-root-dir}} && \
         ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"
-      run: make -C /tmp/jlm -j `nproc` -O all
+      run: make -C ${{inputs.jlm-root-dir}} -j `nproc` -O all
       shell: bash
 
     - name: "Add executables to PATH"
-      run: echo '/tmp/jlm/build' >> $GITHUB_PATH
+      run: echo '${{inputs.jlm-root-dir}}/build' >> $GITHUB_PATH
       shell: bash

--- a/.github/actions/BuildJlm/action.yml
+++ b/.github/actions/BuildJlm/action.yml
@@ -15,10 +15,8 @@ runs:
 
     - name: "Configure jlm"
       run: |
-        cwd=$(pwd) && \
         cd /tmp/jlm && \
-        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}} && \
-        cd ${cwd}
+        ./configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
       shell: bash
 
     - name: "Compile jlm"

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -16,10 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: "Get LLVM apt key"
-      if: ${{inputs.install-llvm == 'true'
-        || inputs.install-clang == 'true'
-        || inputs.install-mlir == 'true'
-        || inputs.install-clang-format == 'true'}}
+      if: ${{inputs.install-llvm == 'true' || inputs.install-clang == 'true'}}
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -1,22 +1,10 @@
 name: "Install packages"
 description: "Installs packages that the llvm-test-suite depends on."
 
-inputs:
-  install-llvm:
-    description: "Install LLVM package. Default is 'false'."
-    default: "false"
-    required: false
-
-  install-clang:
-    description: "Install clang package. Default is 'false'."
-    default: "false"
-    required: false
-
 runs:
   using: "composite"
   steps:
     - name: "Get LLVM apt key"
-      if: ${{inputs.install-llvm == 'true' || inputs.install-clang == 'true'}}
       run: |
         export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then
@@ -29,15 +17,9 @@ runs:
       run: sudo apt-get update
       shell: bash
 
-    - name: "Install LLVM package"
-      if: ${{inputs.install-llvm == 'true'}}
+    - name: "Install LLVM and clang package"
       run: |
-        sudo apt-get install llvm-16-dev
+        sudo apt-get install llvm-16-dev clang-16
         pip install "lit~=16.0"
         pip show lit
-      shell: bash
-
-    - name: "Install clang package"
-      if: ${{inputs.install-clang == 'true'}}
-      run: sudo apt-get install clang-16
       shell: bash

--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -1,0 +1,46 @@
+name: "Install packages"
+description: "Installs packages that the llvm-test-suite depends on."
+
+inputs:
+  install-llvm:
+    description: "Install LLVM package. Default is 'false'."
+    default: "false"
+    required: false
+
+  install-clang:
+    description: "Install clang package. Default is 'false'."
+    default: "false"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Get LLVM apt key"
+      if: ${{inputs.install-llvm == 'true'
+        || inputs.install-clang == 'true'
+        || inputs.install-mlir == 'true'
+        || inputs.install-clang-format == 'true'}}
+      run: |
+        export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
+        if [[ -z $HAS_LLVM_REPOSITORY ]]; then
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+        fi
+      shell: bash
+
+    - name: "Update apt sources"
+      run: sudo apt-get update
+      shell: bash
+
+    - name: "Install LLVM package"
+      if: ${{inputs.install-llvm == 'true'}}
+      run: |
+        sudo apt-get install llvm-16-dev
+        pip install "lit~=16.0"
+        pip show lit
+      shell: bash
+
+    - name: "Install clang package"
+      if: ${{inputs.install-clang == 'true'}}
+      run: sudo apt-get install clang-16
+      shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: BuildJlm
     steps:
+    - uses: actions/checkout@v4
     - name: "Cache"
       uses: actions/cache@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: "Cache"
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}/jlm/*
+        path: ${{ github.workspace }}/../jlm/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: "Run LLVM test suite"
       run: make llvm-run-opt
@@ -53,7 +53,7 @@ jobs:
     - name: "Cache"
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}/jlm/*
+        path: ${{ github.workspace }}/../jlm/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: "Run LLVM test suite"
       run: make llvm-run-andersen-agnostic
@@ -66,7 +66,7 @@ jobs:
     - name: "Cache"
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}/jlm/*
+        path: ${{ github.workspace }}/../jlm/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: "Run LLVM test suite"
       run: make llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: InstallPackages
     steps:
-    - uses: actions/checkout@v4
     - name: "Build cache"
       id: cache-build
       uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   llvm-test-suite:
     runs-on: ubuntu-22.04
+    if: !contains(github.event.pull_request.title, '[DisableCI]')
     steps:
     - uses: actions/checkout@v4
     - name: "Install packages"
@@ -21,6 +22,7 @@ jobs:
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
+    if: !contains(github.event.pull_request.title, '[DisableCI]')
     steps:
     - uses: actions/checkout@v4
     - name: "Install packages"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
 
   llvm-test-suite-steensgaard-agnostic:
     runs-on: ubuntu-22.04
+    if: contains(github.event.pull_request.title, '[DisableCI]') == false
     steps:
     - uses: actions/checkout@v4
     - name: "Install packages"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-22.04
     needs: BuildJlm
     steps:
-    - uses: actions/checkout@v4
     - name: "Cache"
       uses: actions/cache@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,71 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  InstallPackages:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Install packages"
+        uses: ./.github/actions/InstallPackages
+        with:
+          install-llvm: true
+          install-clang: true
+
+  BuildJlm:
+    runs-on: ubuntu-22.04
+    needs: InstallPackages
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Build cache"
+      id: cache-build
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Build jlm"
+      uses: ./.github/actions/BuildJlm
+      with:
+        jlm-root-dir: ${{github.workspace}}/jlm
+        cxx: clang++-16
+
+  llvm-test-suite:
+    runs-on: ubuntu-22.04
+    needs: BuildJlm
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Cache"
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Run LLVM test suite"
+      run: make llvm-run-opt
+
+  llvm-test-suite-andersen-agnostic:
+    runs-on: ubuntu-22.04
+    needs: BuildJlm
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Cache"
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Run LLVM test suite"
+      run: make llvm-run-andersen-agnostic
+
+  llvm-test-suite-steensgaard-agnostic:
+    runs-on: ubuntu-22.04
+    needs: BuildJlm
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Cache"
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Run LLVM test suite"
+      run: make llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,12 +24,12 @@ jobs:
       id: cache-build
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}/jlm/*
+        path: ${{ github.workspace }}/../jlm/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        jlm-root-dir: ${{github.workspace}}/jlm
+        jlm-root-dir: ${{github.workspace}}/../jlm
         cxx: clang++-16
 
   llvm-test-suite:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,82 +5,53 @@ on:
     branches: [ jlm-with-llvm-16 ]
 
 jobs:
-  InstallPackages:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: "Get LLVM apt key"
-        run: |
-          export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
-          if [[ -z $HAS_LLVM_REPOSITORY ]]; then
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-            sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
-          fi
-      - name: "Update apt sources"
-        run: sudo apt-get update
-      - name: "Install LLVM package"
-        run: |
-          sudo apt-get install llvm-16-dev
-          pip install "lit~=16.0"
-          pip show lit
-      - name: "Install clang package"
-        run: sudo apt-get install clang-16
-
-  BuildJlm:
-    runs-on: ubuntu-22.04
-    needs: InstallPackages
-    steps:
-    - name: "Build cache"
-      id: cache-build
-      uses: actions/cache@v4
-      with:
-        path: ${{ github.workspace }}/../jlm/*
-        key: ${{ runner.os }}-${{ github.sha }}-jlm
-    - name: "Clone jlm"
-      run: git clone https://github.com/phate/jlm.git ${{ github.workspace }}/../jlm/
-    - name: "Configure jlm"
-      run: ${{ github.workspace }}/../jlm/configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
-    - name: "Compile jlm"
-      run: make -C ${{ github.workspace }}/../jlm/ -j `nproc` -O all
-      shell: bash
-    - name: "Add executables to PATH"
-      run: echo '${{ github.workspace }}/../jlm/build' >> $GITHUB_PATH
-      shell: bash
-
   llvm-test-suite:
     runs-on: ubuntu-22.04
-    needs: BuildJlm
     steps:
     - uses: actions/checkout@v4
-    - name: "Cache"
-      uses: actions/cache@v4
+    - name: "Install packages"
+      uses: ./.github/actions/InstallPackages
       with:
-        path: ${{ github.workspace }}/../jlm/*
-        key: ${{ runner.os }}-${{ github.sha }}-jlm
+        install-llvm: true
+        install-clang: true
+    - name: "Build jlm"
+      uses: ./.github/actions/BuildJlm
+      with:
+        jlm-root-dir: ${{github.workspace}}/../jlm
+        cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
-    needs: BuildJlm
     steps:
     - uses: actions/checkout@v4
-    - name: "Cache"
-      uses: actions/cache@v4
+    - name: "Install packages"
+      uses: ./.github/actions/InstallPackages
       with:
-        path: ${{ github.workspace }}/../jlm/*
-        key: ${{ runner.os }}-${{ github.sha }}-jlm
+        install-llvm: true
+        install-clang: true
+    - name: "Build jlm"
+      uses: ./.github/actions/BuildJlm
+      with:
+        jlm-root-dir: ${{github.workspace}}/../jlm
+        cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-andersen-agnostic
 
   llvm-test-suite-steensgaard-agnostic:
     runs-on: ubuntu-22.04
-    needs: BuildJlm
     steps:
     - uses: actions/checkout@v4
-    - name: "Cache"
-      uses: actions/cache@v4
+    - name: "Install packages"
+      uses: ./.github/actions/InstallPackages
       with:
-        path: ${{ github.workspace }}/../jlm/*
-        key: ${{ runner.os }}-${{ github.sha }}-jlm
+        install-llvm: true
+        install-clang: true
+    - name: "Build jlm"
+      uses: ./.github/actions/BuildJlm
+      with:
+        jlm-root-dir: ${{github.workspace}}/../jlm
+        cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   llvm-test-suite:
     runs-on: ubuntu-22.04
-    if: !contains(github.event.pull_request.title, '[DisableCI]')
+    if: contains(github.event.pull_request.title, '[DisableCI]') == false
     steps:
     - uses: actions/checkout@v4
     - name: "Install packages"
@@ -22,7 +22,7 @@ jobs:
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
-    if: !contains(github.event.pull_request.title, '[DisableCI]')
+    if: contains(github.event.pull_request.title, '[DisableCI]') == false
     steps:
     - uses: actions/checkout@v4
     - name: "Install packages"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,22 @@ jobs:
   InstallPackages:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
-      - name: "Install packages"
-        uses: ./.github/actions/InstallPackages
-        with:
-          install-llvm: true
-          install-clang: true
+      - name: "Get LLVM apt key"
+        run: |
+          export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
+          if [[ -z $HAS_LLVM_REPOSITORY ]]; then
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+            sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+          fi
+      - name: "Update apt sources"
+        run: sudo apt-get update
+      - name: "Install LLVM package"
+        run: |
+          sudo apt-get install llvm-16-dev
+          pip install "lit~=16.0"
+          pip show lit
+      - name: "Install clang package"
+        run: sudo apt-get install clang-16
 
   BuildJlm:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        jlm-root-dir: ${{github.workspace}}/../jlm
         cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-opt
@@ -34,7 +33,6 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        jlm-root-dir: ${{github.workspace}}/../jlm
         cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-andersen-agnostic
@@ -51,7 +49,6 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        jlm-root-dir: ${{github.workspace}}/../jlm
         cxx: clang++-16
     - name: "Run LLVM test suite"
       run: make llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     - name: "Run LLVM test suite"
       run: |
         pwd
-        make llvm-run-opt
+        make -C jlm llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
@@ -37,7 +37,7 @@ jobs:
       with:
         cxx: clang++-16
     - name: "Run LLVM test suite"
-      run: make llvm-run-andersen-agnostic
+      run: make -C jlm llvm-run-andersen-agnostic
 
   llvm-test-suite-steensgaard-agnostic:
     runs-on: ubuntu-22.04
@@ -53,4 +53,4 @@ jobs:
       with:
         cxx: clang++-16
     - name: "Run LLVM test suite"
-      run: make llvm-run-steensgaard-agnostic
+      run: make -C jlm llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ jlm-with-llvm-16 ]
 
 jobs:
   InstallPackages:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,9 @@ jobs:
       with:
         cxx: clang++-16
     - name: "Run LLVM test suite"
-      run: make llvm-run-opt
+      run: |
+        pwd
+        make llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Install packages"
       uses: ./.github/actions/InstallPackages
-      with:
-        install-llvm: true
-        install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
     - name: "Run LLVM test suite"
@@ -27,9 +24,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Install packages"
       uses: ./.github/actions/InstallPackages
-      with:
-        install-llvm: true
-        install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
     - name: "Run LLVM test suite"
@@ -42,9 +36,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: "Install packages"
       uses: ./.github/actions/InstallPackages
-      with:
-        install-llvm: true
-        install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
     - name: "Run LLVM test suite"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,12 +16,8 @@ jobs:
         install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
-      with:
-        cxx: clang++
     - name: "Run LLVM test suite"
-      run: |
-        pwd
-        make -C jlm llvm-run-opt
+      run: make -C jlm llvm-run-opt
 
   llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
@@ -34,8 +30,6 @@ jobs:
         install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
-      with:
-        cxx: clang++
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-andersen-agnostic
 
@@ -50,7 +44,5 @@ jobs:
         install-clang: true
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
-      with:
-        cxx: clang++
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        cxx: clang++-16
+        cxx: clang++
     - name: "Run LLVM test suite"
       run: |
         pwd
@@ -35,7 +35,7 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        cxx: clang++-16
+        cxx: clang++
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-andersen-agnostic
 
@@ -51,6 +51,6 @@ jobs:
     - name: "Build jlm"
       uses: ./.github/actions/BuildJlm
       with:
-        cxx: clang++-16
+        cxx: clang++
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-steensgaard-agnostic

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ jobs:
   InstallPackages:
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - name: "Install packages"
         uses: ./.github/actions/InstallPackages
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,11 +36,16 @@ jobs:
       with:
         path: ${{ github.workspace }}/../jlm/*
         key: ${{ runner.os }}-${{ github.sha }}-jlm
-    - name: "Build jlm"
-      uses: ./.github/actions/BuildJlm
-      with:
-        jlm-root-dir: ${{github.workspace}}/../jlm
-        cxx: clang++-16
+    - name: "Clone jlm"
+      run: git clone https://github.com/phate/jlm.git ${{ github.workspace }}/../jlm/
+    - name: "Configure jlm"
+      run: ${{ github.workspace }}/../jlm/configure.sh --target release --enable-asserts CXX=${{inputs.cxx}}
+    - name: "Compile jlm"
+      run: make -C ${{ github.workspace }}/../jlm/ -j `nproc` -O all
+      shell: bash
+    - name: "Add executables to PATH"
+      run: echo '${{ github.workspace }}/../jlm/build' >> $GITHUB_PATH
+      shell: bash
 
   llvm-test-suite:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
When we moved to this repository from the jlm-eval-suite repository, we dropped the CI jobs that were present in jlm-eval-suite. This PR fixes this regression by reintroducing the jobs in this repository. However, the jobs are introduced with a convenient way to disable them by simply appending `[DisableCI]` to the PR title. This enables us to break the cycle between the jlm repository and this repository when we, for example, have to update the LLVM version.