### PR TITLE
Update CI to LLVM 17 [DisableCI]

### DIFF
--- a/.github/actions/InstallPackages/action.yml
+++ b/.github/actions/InstallPackages/action.yml
@@ -1,15 +1,21 @@
 name: "Install packages"
 description: "Installs packages that the llvm-test-suite depends on."
 
+inputs:
+  llvm-version:
+    description: "LLVM/ version that is installed"
+    default: "17"
+    required: false
+
 runs:
   using: "composite"
   steps:
     - name: "Get LLVM apt key"
       run: |
-        export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-16)
+        export HAS_LLVM_REPOSITORY=$(find /etc/apt/ -name *.list | xargs cat | grep llvm-toolchain-jammy-${{inputs.llvm-version}})
         if [[ -z $HAS_LLVM_REPOSITORY ]]; then
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+          sudo add-apt-repository --no-update deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{inputs.llvm-version}} main
         fi
       shell: bash
 
@@ -19,7 +25,7 @@ runs:
 
     - name: "Install LLVM and clang package"
       run: |
-        sudo apt-get install llvm-16-dev clang-16
-        pip install "lit~=16.0"
+        sudo apt-get install llvm-${{inputs.llvm-version}}-dev clang-${{inputs.llvm-version}}
+        pip install "lit~=${{inputs.llvm-version}}.0"
         pip show lit
       shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ jlm-with-llvm-16 ]
+    branches: [ jlm-with-llvm-16, jlm-with-llvm-17 ]
 
 jobs:
   llvm-test-suite:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ jlm-with-llvm-16, jlm-with-llvm-17 ]
+    branches: [ jlm-with-llvm-17 ]
 
 jobs:
   llvm-test-suite:


### PR DESCRIPTION
The new base branch for LLVM 17 jlm compile chain is jlm-llvm-17. It was checked out from the jlm-llvm-16 branch. This PR only updates the CI to also use LLVM 17.