### PR TITLE
Add Steensgaard Region-Aware targets and CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,15 @@ jobs:
       uses: ./.github/actions/BuildJlm
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-steensgaard-agnostic
+
+  llvm-test-suite-steensgaard-region-aware:
+    runs-on: ubuntu-22.04
+    if: contains(github.event.pull_request.title, '[DisableCI]') == false
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install packages"
+        uses: ./.github/actions/InstallPackages
+      - name: "Build jlm"
+        uses: ./.github/actions/BuildJlm
+      - name: "Run LLVM test suite"
+        run: make -C jlm llvm-run-steensgaard-region-aware

--- a/MultiSource/Applications/CMakeLists.txt
+++ b/MultiSource/Applications/CMakeLists.txt
@@ -8,9 +8,10 @@ add_subdirectory(d)
 if(NOT ARCH STREQUAL "PowerPC")
 # This test has problems running on powerpc starting with r295538 and should
 # be restored when the issue is corrected.
-  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
+  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED) AND (NOT DEFINED STEENSGAARD_REGIONAWARE_ENABLED))
     # JLC: Andersen with agnostic encoding runs out of memory
     # JLC: Steensgaard with agnostic encoding runs out of memory
+    # JLC: Steensgaard with region-aware encoding runs out of memory
     add_subdirectory(oggenc)
   endif()
 endif()
@@ -53,9 +54,10 @@ if(NOT ARCH STREQUAL "XCore")
   add_subdirectory(siod)
 endif()
 if((NOT ARCH STREQUAL "PowerPC") AND (NOT ARCH STREQUAL "XCore"))
-  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
+  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED) AND (NOT DEFINED STEENSGAARD_REGIONAWARE_ENABLED))
     # JLC: Andersen with agnostic encoding runs out of memory
     # JLC: Steensgaard with agnostic encoding runs out of memory
+    # JLC: Steensgaard with region-aware encoding runs out of memory
     add_subdirectory(sqlite3)
   endif()
 endif()

--- a/jlm/Makefile.sub
+++ b/jlm/Makefile.sub
@@ -57,7 +57,7 @@ llvm-build-steensgaard-region-aware:
 	cmake $(CMAKE_CONFIG) \
 		-B $(LLVM_TEST_BUILD)-steensgaard-region-aware \
 		-C $(LLVM_TEST_ROOT)/cmake/SteensgaardRegionAware.cmake $(LLVM_TEST_GIT)
-	cd $(LLVM_TEST_BUILD)-steensgaard-region-aware && make VERBOSE=1 SHELL="/bin/bash -x"
+	cd $(LLVM_TEST_BUILD)-steensgaard-region-aware && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
 .PHONY: llvm-build-cne
 llvm-build-cne:

--- a/jlm/Makefile.sub
+++ b/jlm/Makefile.sub
@@ -52,6 +52,13 @@ llvm-build-steensgaard-agnostic:
 		-C $(LLVM_TEST_ROOT)/cmake/SteensgaardAgnostic.cmake $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_BUILD)-steensgaard-agnostic && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
+.PHONY: llvm-build-steensgaard-region-aware
+llvm-build-steensgaard-region-aware:
+	cmake $(CMAKE_CONFIG) \
+		-B $(LLVM_TEST_BUILD)-steensgaard-region-aware \
+		-C $(LLVM_TEST_ROOT)/cmake/SteensgaardRegionAware.cmake $(LLVM_TEST_GIT)
+	cd $(LLVM_TEST_BUILD)-steensgaard-region-aware && make VERBOSE=1 SHELL="/bin/bash -x"
+
 .PHONY: llvm-build-cne
 llvm-build-cne:
 	mkdir -p $(LLVM_TEST_BUILD)-cne
@@ -151,6 +158,9 @@ llvm-run-andersen-agnostic: llvm-build-andersen-agnostic
 llvm-run-steensgaard-agnostic: llvm-build-steensgaard-agnostic
 	cd $(LLVM_TEST_BUILD)-steensgaard-agnostic && lit -v -j `nproc` -o results.json .
 
+.PHONY: llvm-run-steensgaard-region-aware
+llvm-run-steensgaard-region-aware: llvm-build-steensgaard-region-aware
+	cd $(LLVM_TEST_BUILD)-steensgaard-region-aware && lit -v -j `nproc` -o results.json .
 
 .PHONY: llvm-run-cne
 llvm-run-cne: llvm-build-cne

--- a/jlm/cmake/SteensgaardRegionAware.cmake
+++ b/jlm/cmake/SteensgaardRegionAware.cmake
@@ -1,0 +1,6 @@
+set(OPTFLAGS "${OPTFLAGS} -JAASteensgaardRegionAware")
+
+set(STEENSGAARD_REGIONAWARE_ENABLED "YES" CACHE STRING "Determines whether Steensgaard alias analysis with region-aware encoding is enabled.")
+set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")


### PR DESCRIPTION
Adding the Steensgaard Region-Aware analyses to the make targets and the CI to keep track of it. Currently, we still have the following tests failing:

```
 Failed Tests (12):
  test-suite :: MultiSource/Applications/Burg/burg.test
  test-suite :: MultiSource/Benchmarks/MallocBench/espresso/espresso.test
  test-suite :: MultiSource/Benchmarks/Olden/em3d/em3d.test
  test-suite :: MultiSource/Benchmarks/Olden/perimeter/perimeter.test
  test-suite :: MultiSource/Benchmarks/Olden/treeadd/treeadd.test
  test-suite :: MultiSource/Benchmarks/Olden/tsp/tsp.test
  test-suite :: MultiSource/Benchmarks/Prolangs-C/allroots/allroots.test
  test-suite :: MultiSource/Benchmarks/Prolangs-C/bison/mybison.test
  test-suite :: MultiSource/Benchmarks/Prolangs-C/gnugo/gnugo.test
  test-suite :: MultiSource/Benchmarks/mafft/pairlocalalign.test
  test-suite :: MultiSource/Benchmarks/sim/sim.test
  test-suite :: SingleSource/Regression/C/gcc-c-torture/execute/GCC-C-execute-pr38819.test
Testing Time: 659.33s
  Passed: 1765
  Failed:   12
  ```