### PR TITLE
Add Andersen Region-Aware targets and CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,18 @@ jobs:
     - name: "Run LLVM test suite"
       run: make -C jlm llvm-run-andersen-agnostic
 
+  llvm-test-suite-andersen-region-aware:
+    runs-on: ubuntu-22.04
+    if: contains(github.event.pull_request.title, '[DisableCI]') == false
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install packages"
+        uses: ./.github/actions/InstallPackages
+      - name: "Build jlm"
+        uses: ./.github/actions/BuildJlm
+      - name: "Run LLVM test suite"
+        run: make -C jlm llvm-run-andersen-region-aware
+
   llvm-test-suite-steensgaard-agnostic:
     runs-on: ubuntu-22.04
     if: contains(github.event.pull_request.title, '[DisableCI]') == false

--- a/MultiSource/Applications/CMakeLists.txt
+++ b/MultiSource/Applications/CMakeLists.txt
@@ -8,8 +8,9 @@ add_subdirectory(d)
 if(NOT ARCH STREQUAL "PowerPC")
 # This test has problems running on powerpc starting with r295538 and should
 # be restored when the issue is corrected.
-  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
+  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED) AND (NOT DEFINED ANDERSEN_REGIONAWARE_ENABLED))
     # JLC: Andersen with agnostic encoding runs out of memory
+    # JLC: Andersen with region-aware encoding runs out of memory
     # JLC: Steensgaard with agnostic encoding runs out of memory
     add_subdirectory(oggenc)
   endif()
@@ -42,8 +43,9 @@ if(NOT TARGET_OS STREQUAL "SunOS")
 #  add_subdirectory(kimwitu++)
 endif()
 if(NOT TARGET_OS STREQUAL "SunOS")
-  if(NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC)
+  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED ANDERSEN_REGIONAWARE_ENABLED))
     # JLC: Andersen with agnostic encoding runs out of memory
+    # JLC: Andersen with region-aware encoding runs out of memory
     add_subdirectory(SPASS)
   endif()
 endif()
@@ -53,8 +55,9 @@ if(NOT ARCH STREQUAL "XCore")
   add_subdirectory(siod)
 endif()
 if((NOT ARCH STREQUAL "PowerPC") AND (NOT ARCH STREQUAL "XCore"))
-  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
+  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED) AND (NOT DEFINED ANDERSEN_REGIONAWARE_ENABLED))
     # JLC: Andersen with agnostic encoding runs out of memory
+    # JLC: Andersen with region-aware encoding runs out of memory
     # JLC: Steensgaard with agnostic encoding runs out of memory
     add_subdirectory(sqlite3)
   endif()

--- a/jlm/Makefile.sub
+++ b/jlm/Makefile.sub
@@ -45,6 +45,13 @@ llvm-build-andersen-agnostic:
 		-C$(LLVM_TEST_ROOT)/cmake/AndersenAgnostic.cmake $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_BUILD)-andersen-agnostic && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
+.PHONY: llvm-build-andersen-region-aware
+llvm-build-andersen-region-aware:
+	cmake $(CMAKE_CONFIG) \
+		-B $(LLVM_TEST_BUILD)-andersen-region-aware \
+		-C $(LLVM_TEST_ROOT)/cmake/AndersenRegionAware.cmake $(LLVM_TEST_GIT)
+	cd $(LLVM_TEST_BUILD)-andersen-region-aware && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
+
 .PHONY: llvm-build-steensgaard-agnostic
 llvm-build-steensgaard-agnostic:
 	cmake $(CMAKE_CONFIG) \
@@ -146,6 +153,10 @@ llvm-run-aa: llvm-build-aa
 .PHONY: llvm-run-andersen-agnostic
 llvm-run-andersen-agnostic: llvm-build-andersen-agnostic
 	cd $(LLVM_TEST_BUILD)-andersen-agnostic && lit -v -j `nproc` -o results.json .
+
+.PHONY: llvm-run-andersen-region-aware
+llvm-run-andersen-region-aware: llvm-build-andersen-region-aware
+	cd $(LLVM_TEST_BUILD)-steensgaard-andersen-aware && lit -v -j `nproc` -o results.json .
 
 .PHONY: llvm-run-steensgaard-agnostic
 llvm-run-steensgaard-agnostic: llvm-build-steensgaard-agnostic

--- a/jlm/Makefile.sub
+++ b/jlm/Makefile.sub
@@ -156,7 +156,7 @@ llvm-run-andersen-agnostic: llvm-build-andersen-agnostic
 
 .PHONY: llvm-run-andersen-region-aware
 llvm-run-andersen-region-aware: llvm-build-andersen-region-aware
-	cd $(LLVM_TEST_BUILD)-steensgaard-andersen-aware && lit -v -j `nproc` -o results.json .
+	cd $(LLVM_TEST_BUILD)-andersen-region-aware && lit -v -j `nproc` -o results.json .
 
 .PHONY: llvm-run-steensgaard-agnostic
 llvm-run-steensgaard-agnostic: llvm-build-steensgaard-agnostic

--- a/jlm/cmake/AndersenRegionAware.cmake
+++ b/jlm/cmake/AndersenRegionAware.cmake
@@ -1,0 +1,6 @@
+set(OPTFLAGS "${OPTFLAGS} -JAAAndersenRegionAware")
+
+set(ANDERSEN_REGIONAWARE_ENABLED "YES" CACHE STRING "Determines whether Andersen alias analysis with region-aware encoding is enabled.")
+set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")


### PR DESCRIPTION
Adding the Andersen Region-Aware analysis to the make targets and the CI to keep track of it.