### PR TITLE
add NodePushOut and a second StoreValueForwarding to AndersenRegionAware.cmake

### DIFF
--- a/jlm/Makefile.sub
+++ b/jlm/Makefile.sub
@@ -235,4 +235,4 @@ llvm-run-opt: llvm-build-opt
 
 .PHONY: llvm-clean
 llvm-clean:
-	rm -rf $(LLVM_TEST_BUILD) $(LLVM_TEST_BUILD)-opt
+	rm -rf $(LLVM_TEST_BUILD)*

--- a/jlm/cmake/AndersenRegionAware.cmake
+++ b/jlm/cmake/AndersenRegionAware.cmake
@@ -1,4 +1,8 @@
-set(OPTFLAGS "${OPTFLAGS} -JFunctionInlining -JPredicateCorrelation -JLoopUnswitching -JCommonNodeElimination -JInvariantValueRedirection -JDeadNodeElimination -JAAAndersenRegionAware -JStoreValueForwarding -JInvariantValueRedirection -JPredicateCorrelation -JLoadChainSeparation -JNodeReduction -JDeadNodeElimination -JLoopUnswitching -JInvariantValueRedirection -JDeadNodeElimination -JInvariantValueRedirection -JDeadNodeElimination -JNodeReduction -JCommonNodeElimination -JDeadNodeElimination -JNodePullIn -JInvariantValueRedirection -JDeadNodeElimination -JLoopUnrolling -JInvariantValueRedirection -JIfConversion -JCommonNodeElimination -JDeadNodeElimination")
+set(OPTFLAGS "${OPTFLAGS} -JFunctionInlining -JPredicateCorrelation -JLoopUnswitching -JCommonNodeElimination -JInvariantValueRedirection -JDeadNodeElimination \
+ -JAAAndersenRegionAware -JStoreValueForwarding -JNodePushOut -JCommonNodeElimination -JStoreValueForwarding -JInvariantValueRedirection -JPredicateCorrelation \
+ -JLoadChainSeparation -JNodeReduction -JDeadNodeElimination -JLoopUnswitching -JCommonNodeElimination -JInvariantValueRedirection -JDeadNodeElimination \
+ -JNodeReduction -JCommonNodeElimination -JDeadNodeElimination -JNodePullIn -JCommonNodeElimination -JInvariantValueRedirection -JDeadNodeElimination \
+ -JLoopUnrolling -JInvariantValueRedirection -JIfConversion -JCommonNodeElimination -JDeadNodeElimination")
 
 set(ANDERSEN_REGIONAWARE_ENABLED "YES" CACHE STRING "Determines whether Andersen alias analysis with region-aware encoding is enabled.")
 set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")


### PR DESCRIPTION
Also fixes that make llvm-clean only targets very specific build dirs.

Note that this change still passes all 1775 tests